### PR TITLE
Add basic authentication

### DIFF
--- a/bin/quickftp
+++ b/bin/quickftp
@@ -18,16 +18,18 @@ end
 
 host = get_argv('-h')
 port = get_argv('-p').to_i
+user = get_argv('--user')
+password = get_argv('--password')
 
 if ARGV.any? {|f| f == '--help'}
   # help mode
   puts 'Usage:'
-  puts '  quickftp [path/to/directory] [-h HOST] [-p PORT]'
+  puts '  quickftp [path/to/directory] [-h HOST] [-p PORT] [--user USER] [--password PASSWORD]'
 else
   path = ARGV.first || '.'
   path = Pathname.new(path).realpath.to_s
 
-  driver = Quickftp::Driver.new(path)
+  driver = Quickftp::Driver.new({ dir: path, user: user, password: password })
   server = Ftpd::FtpServer.new(driver)
   server.server_name = "Quickftp"
   server.server_version = Quickftp::VERSION

--- a/lib/quickftp/driver.rb
+++ b/lib/quickftp/driver.rb
@@ -1,11 +1,17 @@
 module Quickftp
   class Driver
-    def initialize(dir)
-      @dir = dir
+    def initialize(**options)
+      @dir = options[:dir]
+      @user = options[:user]
+      @password = options[:password]
     end
 
     def authenticate(user, password)
-      true
+      if @user && @password
+        @user == user && @password == password
+      else
+        true
+      end
     end
 
     def file_system(user)

--- a/test/lib/quickftp/test_driver.rb
+++ b/test/lib/quickftp/test_driver.rb
@@ -5,4 +5,15 @@ class TestDriver < Minitest::Test
     driver = Quickftp::Driver.new('.')
     assert driver.authenticate('someone', 'super secret password')
   end
+
+  def test_authenticates_wrong_password
+    driver = Quickftp::Driver.new('.', "someone", "incorrect password")
+    assert !driver.authenticate('someone', 'super secret password')
+  end
+
+  def test_authenticates_user
+    driver = Quickftp::Driver.new('.', "someone", 'super secret password')
+    assert driver.authenticate('someone', 'super secret password')
+  end
+
 end


### PR DESCRIPTION
Hi,

I have added a basic auth support in the command line.

```bash
> quickftp --user aschen --password azerty
```
Will allow only user `aschen` with password `azerty` to connect.